### PR TITLE
blob/gcsblog: return additional error codes

### DIFF
--- a/blob/gcsblob/gcsblob.go
+++ b/blob/gcsblob/gcsblob.go
@@ -255,10 +255,14 @@ func (b *bucket) ErrorCode(err error) gcerrors.ErrorCode {
 	}
 	if gerr, ok := err.(*googleapi.Error); ok {
 		switch gerr.Code {
+        case http.StatusForbidden:
+            return gcerrors.PermissionDenied
 		case http.StatusNotFound:
 			return gcerrors.NotFound
 		case http.StatusPreconditionFailed:
 			return gcerrors.FailedPrecondition
+        case http.StatusTooManyRequests:
+			return gcerrors.ResourceExhausted
 		}
 	}
 	return gcerrors.Unknown


### PR DESCRIPTION
This adds additional return codes for `ErrorCode` as per the Google Cloud
documentation here:

https://cloud.google.com/storage/docs/json_api/v1/status-codes#standardcodes